### PR TITLE
added rgb background value for older browsers

### DIFF
--- a/modules/core/client/css/header.css
+++ b/modules/core/client/css/header.css
@@ -16,6 +16,7 @@
 .overlay {
     width: 100%;
     height: 100%;
+    background-color: rgb(0,0,0);
     background-color: rgba(0,0,0,.5);
     position: fixed;
     top: 64px;


### PR DESCRIPTION
There's an error coming up on deployment presently - it doesn't break anything in reasonably-current browsers, but to make it go away, we just need this line...
