### PR TITLE
All admins can now edit or delete any job

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -6,8 +6,8 @@ module.exports = {
   db: {
     uri: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://admin:pass@ds041603.mongolab.com:41603/ham_tst',
     options: {
-      user: '',
-      pass: ''
+      user: 'admin',
+      pass: 'pass'
     },
     // Enable mongoose debug mode
     debug: process.env.MONGODB_DEBUG || false

--- a/modules/users/client/controllers/admin/jobs.client.controller.js
+++ b/modules/users/client/controllers/admin/jobs.client.controller.js
@@ -23,7 +23,7 @@ angular.module('jobs').controller('JobsController', ['$scope', '$stateParams', '
 
       // Redirect after save
       job.$save(function (response) {
-        $location.path('admin/jobs/' + response._id);
+        $location.path('admin/jobs');
 
         // Clear form fields
         $scope.title = '';

--- a/modules/users/client/views/admin/view-job.client.view.html
+++ b/modules/users/client/views/admin/view-job.client.view.html
@@ -2,11 +2,11 @@
   <div class="page-header">
     <h1 ng-bind="job.title"></h1>
   </div>
-  <div class="pull-right" ng-show="authentication.user._id == job.user._id">
+  <div class="pull-right">
     <a class="btn waves-effect waves-light" ui-sref="jobs.edit({jobId: job._id})">
       <i class="material-icons left">edit</i><span>Edit</span>
     </a>
-    <a class="waves-effect waves-light btn" ng-click="remove();" ng-if="user._id !== authentication.user._id">
+    <a class="waves-effect waves-light btn" ng-click="remove();">
       <i class="material-icons left">delete</i><span>Remove</span>
     </a>
   </div>


### PR DESCRIPTION
Changes:
1) Fixed small error where admins could not edit or delete jobs that they did not post. 
2) Rerouted back to job list after creating new job, rather than routing to view-job view. 
3) A dependency or something might have changed with Mongo. I now need to explicitly provide the user and password of the database owner in order for me to connect. Double check that this change still allows everyone else to connect to the DB

Comments:
Login as Test Admin and double check that you can edit or delete jobs I posted. Also hopefully the app still works for everyone else since I made the change in development.js
