### PR TITLE
Fixed Referral bug

### DIFF
--- a/modules/users/client/controllers/general/referrals.client.controller.js
+++ b/modules/users/client/controllers/general/referrals.client.controller.js
@@ -101,5 +101,23 @@ angular.module('referrals').controller('ReferralsController', ['$scope', '$state
           return false; // hide
         }
     };
+
+    $scope.getHighestRole = function() {
+        var roles;
+        if ($scope.authentication.user && $scope.authentication.user.roles) {
+
+            roles = $scope.authentication.user.roles;
+
+            if (roles.indexOf('admin') !== -1) {
+                return 'admin';
+            } else if (roles.indexOf('user') !== -1) {
+                return 'user';
+            }
+
+            return '';
+        }
+
+        return '';
+    };
   }
 ]);

--- a/modules/users/client/views/admin/view-referral.client.view.html
+++ b/modules/users/client/views/admin/view-referral.client.view.html
@@ -3,10 +3,10 @@
     <h1 ng-bind="referral.title"></h1>
   </div>
   <div class="pull-right">
-    <a class="btn waves-effect waves-light" ui-sref="referrals.edit({referralId: referral._id})">
+    <a class="btn waves-effect waves-light" ng-show="getHighestRole() == 'admin';" ui-sref="referrals.edit({referralId: referral._id})">
       <i class="material-icons left">edit</i><span>Edit</span>
     </a>
-    <a class="waves-effect waves-light btn" ng-click="remove();">
+    <a class="waves-effect waves-light btn" ng-show="getHighestRole() == 'admin';" ng-click="remove();">
       <i class="material-icons left">delete</i><span>Remove</span>
     </a>
   </div>


### PR DESCRIPTION
Fixed the bug where Employees could see the Edit and Delete buttons within the Referrals.

Changes:
1) Took method from Header controller that checked the current user's role and put it in Referrals controller
2) Added ng-show stuff that hid the Edit and Delete buttons if the current user was not an Admin.
